### PR TITLE
fix for class score interpretation

### DIFF
--- a/Examples/MAX78000/micro-ROS/object_detector/src/cnn/post_process.c
+++ b/Examples/MAX78000/micro-ROS/object_detector/src/cnn/post_process.c
@@ -265,6 +265,8 @@ void get_indices(int* ar_idx, int* scale_idx, int* rel_idx, int prior_idx)
 
 int8_t check_for_validity(int8_t *cl_addr)
 {
+    return 1;
+    /*
     int ch;
     int8_t validity = 0;
     for (ch = 1; ch < (NUM_CLASSES); ++ch) {
@@ -275,6 +277,7 @@ int8_t check_for_validity(int8_t *cl_addr)
     }
 
     return validity;
+    */
 }
 
 void calc_softmax(int8_t *prior_cls_vals, int prior_idx)

--- a/Examples/MAX78000/micro-ROS/object_detector/src/cnn/post_process.h
+++ b/Examples/MAX78000/micro-ROS/object_detector/src/cnn/post_process.h
@@ -36,12 +36,12 @@
 
 #define LOC_DIM 4
 #define KPTS_DIM 8
-#define NUM_PRIORS_PER_AR 388
+#define NUM_PRIORS_PER_AR 387
 #define NUM_PRIORS        NUM_PRIORS_PER_AR* NUM_ARS
 
 #define MAX_PRIORS  20
 
-#define MIN_CLASS_SCORE     128 // ~0.5*256
+#define MIN_CLASS_SCORE     50 // ~0.5*256
 #define MAX_ALLOWED_OVERLAP 0.1f
 
 #define TFT_W 320


### PR DESCRIPTION
removes the optimization to fetch the output class probabilities. So the priors with QR probability <0.5 can be chosen as a detected object.